### PR TITLE
Add option to hide post date

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -17,9 +17,13 @@
                   class="text-primary">{{ . | title | humanize }}</a>
                 {{ end }}
                 <a href="{{ .Permalink }}" class="h5 d-block my-3">{{ .Title | markdownify }}</a>
-                <div class="mb-3"><span>By {{ .Site.Params.Author }}</span> <span
-                    class="border-bottom border-primary px-2 mx-1"></span>
-                  <span>{{ .PublishDate.Format "02 January 2006" }}</span></div>
+                <div class="mb-3">
+                  <span>By {{ .Site.Params.Author }}</span>
+                  {{ if not .Params.HideDate }}
+                  <span class="border-bottom border-primary px-2 mx-1"></span>
+                  <span>{{ .PublishDate.Format "02 January 2006" }}</span>
+                  {{ end }}
+                </div>
                 <p class="card-text">{{ .Summary }}</p>
                 <a href="{{ .Permalink }}" class="btn btn-outline-primary">read more</a>
               </div>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -9,9 +9,13 @@
           class="text-primary">{{ . | title | humanize }}</a>
         {{ end }}
         <h2>{{ .Title | markdownify }}</h2>
-        <div class="mb-3"><span>By {{ .Site.Params.Author }}</span> <span
-            class="border-bottom border-primary px-2 mx-1"></span>
-          <span>{{ .PublishDate.Format "02 January 2006" }}</span></div>
+        <div class="mb-3">
+          <span>By {{ .Site.Params.Author }}</span>
+          {{ if not .Params.HideDate }}
+          <span class="border-bottom border-primary px-2 mx-1"></span>
+          <span>{{ .PublishDate.Format "02 January 2006" }}</span>
+          {{ end }}
+        </div>
         <img src="{{ .Params.Image | absURL }}" class="img-fluid w-100 mb-4" alt="{{ .Title | markdownify }}">
         <div class="content mb-5">
           {{ .Content }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -14,9 +14,13 @@
             </div>
             <div class="col-md-6 offset-md-1">
               <div class="card-body">
-                <div class="mb-3"><span>By {{ .Site.Params.Author }}</span> <span
-                    class="border-bottom border-primary px-2 mx-1"></span>
-                  <span>{{ .PublishDate.Format "02 January 2006" }}</span></div>
+                <div class="mb-3">
+                  <span>By {{ .Site.Params.Author }}</span>
+                  {{ if not .Params.HideDate }}
+                  <span class="border-bottom border-primary px-2 mx-1"></span>
+                  <span>{{ .PublishDate.Format "02 January 2006" }}</span>
+                  {{ end }}
+                </div>
                 <a href="{{ .Permalink }}"
                   class="h1 font-weight-bold d-block text-dark mb-4 card-title">{{ .Title | markdownify }}</a>
                 <p class="card-text">{{.Summary}}...</p>
@@ -40,9 +44,13 @@
         <article class="media">
           <div class="recent-post-thumb mr-3" style="background-image: url('{{ .Params.Image | absURL }}');"></div>
           <div class="media-body">
-            <div class="mb-3"><span>By {{ .Site.Params.Author }}</span> <span
-                class="border-bottom border-primary px-2 mx-1"></span>
-              <span>{{ .PublishDate.Format "02 Jan 2006" }}</span></div>
+            <div class="mb-3">
+              <span>By {{ .Site.Params.Author }}</span>
+              {{ if not .Params.HideDate }}
+              <span class="border-bottom border-primary px-2 mx-1"></span>
+              <span>{{ .PublishDate.Format "02 Jan 2006" }}</span>
+              {{ end }}
+            </div>
             <a href="{{ .Permalink }}" class="h5 d-block mb-3">{{ .Title | markdownify }}</a>
             <a href="{{ .Permalink }}" class="btn btn-outline-primary">read more</a>
           </div>
@@ -71,9 +79,13 @@
                   class="text-primary">{{ . | title | humanize }}</a>
                 {{ end }}
                 <a href="{{ .Permalink }}" class="h5 d-block my-3">{{ .Title | markdownify }}</a>
-                <div class="mb-3"><span>By {{ .Site.Params.Author }}</span> <span
-                    class="border-bottom border-primary px-2 mx-1"></span>
-                  <span>{{ .PublishDate.Format "02 January 2006" }}</span></div>
+                <div class="mb-3">
+                  <span>By {{ .Site.Params.Author }}</span>
+                  {{ if not .Params.HideDate }}
+                  <span class="border-bottom border-primary px-2 mx-1"></span>
+                  <span>{{ .PublishDate.Format "02 January 2006" }}</span>
+                  {{ end }}
+                </div>
                 <p class="card-text">{{ .Summary }}</p>
                 <a href="{{ .Permalink }}" class="btn btn-outline-primary">read more</a>
               </div>


### PR DESCRIPTION
Sometimes you do not want to show the date of a post. For example for a page where the it's irrelevant at which date it was written or where you do not want the reader to know that date.

Usage:

```
---
title: "Test"
date: 2019-11-16T21:27:53+01:00
draft: true
hidedate: true
---
```