### PR TITLE
fix variable and string typos in example site

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -39,21 +39,21 @@ disqusShortname = ""
   [[params.plugins.js]]
   URL = "plugins/search/search.js"
 
-  
+
 ############################## navigation ###############################
 [menu]
-  
+
   # main menu
   [[menu.main]]
   name = "About"
   URL = "about"
   weight = 1
-  
+
   [[menu.main]]
   name = "Post"
   URL = "blog"
   weight = 2
-  
+
   [[menu.main]]
   name = "Contact"
   URL = "contact"
@@ -64,12 +64,12 @@ disqusShortname = ""
   name = "About"
   URL = "about"
   weight = 1
-  
+
   [[menu.footer]]
   name = "Post"
   URL = "blog"
   weight = 2
-  
+
   [[menu.footer]]
   name = "Contact"
   URL = "contact"
@@ -84,7 +84,7 @@ home = "Home"
 description = "This is meta description"
 author = "Themefisher"
 # Google Analitycs
-googleAnalitycsID = "Your ID"
+googleAnalyticsID = "Your ID"
 # Contact Information
 mobile = "0124857985320"
 email = "demo@email.com"

--- a/exampleSite/content/blog/post-1.md
+++ b/exampleSite/content/blog/post-1.md
@@ -10,8 +10,8 @@ image: "images/featured-post/post-1.jpg"
 description: "this is meta description"
 
 # taxonomies
-categories: 
-  - "Android And Gmaing"
+categories:
+  - "Android And Gaming"
 tags:
   - "Photos"
   - "Game"
@@ -57,8 +57,8 @@ Strikethrough uses two tildes. ~~Scratch this.~~
 
 Or leave it empty and use the [link text itself].
 
-URLs and URLs in angle brackets will automatically get turned into links. 
-http://www.example.com or <http://www.example.com> and sometimes 
+URLs and URLs in angle brackets will automatically get turned into links.
+http://www.example.com or <http://www.example.com> and sometimes
 example.com (but not on Github, for example).
 
 Some text to show that the reference links can follow later.
@@ -101,14 +101,14 @@ Inline `code` has `back-ticks around` it.
 var s = "JavaScript syntax highlighting";
 alert(s);
 ```
- 
+
 ```python
 s = "Python syntax highlighting"
 print s
 ```
- 
+
 ```
-No language indicated, so no syntax highlighting. 
+No language indicated, so no syntax highlighting.
 But let's throw in a <b>tag</b>.
 ```
 
@@ -146,7 +146,7 @@ Colons can be used to align columns.
 | zebra stripes | are neat      |    $1 |
 
 There must be at least 3 dashes separating each header cell.
-The outer pipes (|) are optional, and you don't need to make the 
+The outer pipes (|) are optional, and you don't need to make the
 raw Markdown line up prettily. You can also use inline Markdown.
 
 Markdown | Less | Pretty


### PR DESCRIPTION
I used this theme for my blog, and it's really good! I just noticed the typos in the example site (which I used as the template) so I just fixed them.